### PR TITLE
Feature/change logic update view

### DIFF
--- a/lib/presenter/subject_edit_or_delete.dart
+++ b/lib/presenter/subject_edit_or_delete.dart
@@ -12,6 +12,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 
 class SubjectEditOrDelete extends StatefulWidget {
   final Subject subject;
+
   const SubjectEditOrDelete({Key key, this.subject}) : super(key: key);
 
   @override
@@ -168,7 +169,8 @@ class _SubjectEditOrDeleteState extends State<SubjectEditOrDelete> {
           ),
           Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
             StoreConnector<AppState, VoidCallback>(converter: (store) {
-              return () => store..dispatch(UpdateSubject(_submit(),new SubjectOverview()));
+              return () => store
+                ..dispatch(UpdateSubject(_submit(), new SubjectOverview()));
             }, builder: (context, callback) {
               return new IconButton(
                 icon: Icon(

--- a/lib/presenter/subject_edit_or_delete.dart
+++ b/lib/presenter/subject_edit_or_delete.dart
@@ -4,6 +4,7 @@ import 'package:easy_study/model/exam_type.dart';
 import 'package:easy_study/model/priority.dart';
 import 'package:easy_study/model/subject.dart';
 import 'package:easy_study/store/app_state.dart';
+import 'package:easy_study/view/subject_overview.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hsvcolor_picker/flutter_hsvcolor_picker.dart';
@@ -167,7 +168,7 @@ class _SubjectEditOrDeleteState extends State<SubjectEditOrDelete> {
           ),
           Row(mainAxisAlignment: MainAxisAlignment.center, children: <Widget>[
             StoreConnector<AppState, VoidCallback>(converter: (store) {
-              return () => store..dispatch(UpdateSubject(_submit()));
+              return () => store..dispatch(UpdateSubject(_submit(),new SubjectOverview()));
             }, builder: (context, callback) {
               return new IconButton(
                 icon: Icon(

--- a/lib/presenter/time_tracking.dart
+++ b/lib/presenter/time_tracking.dart
@@ -102,13 +102,13 @@ class _TimeTracking extends State<TimeTracking> {
                           new FloatingActionButton(
                               backgroundColor: Colors.green,
                               onPressed: () => callback
-                                  .dispatch(UpdateSubject(_startWatch())),
+                                  .dispatch(UpdateSubject(_startWatch(),null)),
                               child: new Icon(Icons.play_arrow)),
                           SizedBox(width: 40.0),
                           new FloatingActionButton(
                               backgroundColor: Colors.red,
                               onPressed: () => callback
-                                ..dispatch(UpdateSubject(_stopWatch())),
+                                ..dispatch(UpdateSubject(_stopWatch(),null)),
                               child: new Icon(Icons.stop)),
                           SizedBox(width: 20.0),
                         ],

--- a/lib/presenter/time_tracking.dart
+++ b/lib/presenter/time_tracking.dart
@@ -102,13 +102,13 @@ class _TimeTracking extends State<TimeTracking> {
                           new FloatingActionButton(
                               backgroundColor: Colors.green,
                               onPressed: () => callback
-                                  .dispatch(UpdateSubject(_startWatch(),null)),
+                                  .dispatch(UpdateSubject(_startWatch(), null)),
                               child: new Icon(Icons.play_arrow)),
                           SizedBox(width: 40.0),
                           new FloatingActionButton(
                               backgroundColor: Colors.red,
                               onPressed: () => callback
-                                ..dispatch(UpdateSubject(_stopWatch(),null)),
+                                ..dispatch(UpdateSubject(_stopWatch(), null)),
                               child: new Icon(Icons.stop)),
                           SizedBox(width: 20.0),
                         ],

--- a/lib/store/app_state.dart
+++ b/lib/store/app_state.dart
@@ -25,7 +25,7 @@ class AddNewSubject {
   final Subject subject;
   AddNewSubject(this.subject);
 }
-
+//TODO: add final Widget widget to this class
 class UpdateSubject {
   final Subject subject;
   UpdateSubject(this.subject);
@@ -47,7 +47,7 @@ class ChangeView {
 AppState _addNewSubject(AppState state, AddNewSubject action) =>
     new AppState(dbHelper: state.dbHelper, widget: new SubjectOverview())
       ..dbHelper.addNewSubject(action.subject);
-
+//TODO: widget: will get action.widget -that it will reviece from method call.
 AppState _updateSubject(AppState state, UpdateSubject action) =>
     new AppState(dbHelper: state.dbHelper, widget: state.widget)
       ..dbHelper.updateSubject(action.subject);

--- a/lib/store/app_state.dart
+++ b/lib/store/app_state.dart
@@ -23,23 +23,28 @@ final searchReducer = combineReducers<AppState>([
 
 class AddNewSubject {
   final Subject subject;
+
   AddNewSubject(this.subject);
 }
-//TODO: add final Widget widget to this class
+
 class UpdateSubject {
   final Widget widget;
   final Subject subject;
-  UpdateSubject(this.subject,this.widget);
+
+  UpdateSubject(this.subject, this.widget);
 }
 
 class DeleteSubject {
   final int id;
+
   DeleteSubject(this.id);
 }
 
 class ChangeView {
   final Widget widget;
+
   ChangeView(this.widget);
+
   bool showFAB() {
     return widget.toString() == "SubjectOverview";
   }
@@ -48,10 +53,11 @@ class ChangeView {
 AppState _addNewSubject(AppState state, AddNewSubject action) =>
     new AppState(dbHelper: state.dbHelper, widget: new SubjectOverview())
       ..dbHelper.addNewSubject(action.subject);
-//TODO: widget: will get action.widget -that it will reviece from method call.
-AppState _updateSubject(AppState state, UpdateSubject action) =>
-    new AppState(dbHelper: state.dbHelper, widget: action.widget == null ? state.widget: action.widget)
-      ..dbHelper.updateSubject(action.subject);
+
+AppState _updateSubject(AppState state, UpdateSubject action) => new AppState(
+    dbHelper: state.dbHelper,
+    widget: action.widget == null ? state.widget : action.widget)
+  ..dbHelper.updateSubject(action.subject);
 
 AppState _deleteSubject(AppState state, DeleteSubject action) =>
     new AppState(dbHelper: state.dbHelper, widget: new SubjectOverview())

--- a/lib/store/app_state.dart
+++ b/lib/store/app_state.dart
@@ -27,8 +27,9 @@ class AddNewSubject {
 }
 //TODO: add final Widget widget to this class
 class UpdateSubject {
+  final Widget widget;
   final Subject subject;
-  UpdateSubject(this.subject);
+  UpdateSubject(this.subject,this.widget);
 }
 
 class DeleteSubject {
@@ -49,7 +50,7 @@ AppState _addNewSubject(AppState state, AddNewSubject action) =>
       ..dbHelper.addNewSubject(action.subject);
 //TODO: widget: will get action.widget -that it will reviece from method call.
 AppState _updateSubject(AppState state, UpdateSubject action) =>
-    new AppState(dbHelper: state.dbHelper, widget: state.widget)
+    new AppState(dbHelper: state.dbHelper, widget: action.widget == null ? state.widget: action.widget)
       ..dbHelper.updateSubject(action.subject);
 
 AppState _deleteSubject(AppState state, DeleteSubject action) =>

--- a/lib/view/progress_summary.dart
+++ b/lib/view/progress_summary.dart
@@ -8,12 +8,15 @@ import 'tween.dart';
 
 class ProgressSummary extends StatefulWidget {
   final List<Subject> _subjects;
+
   ProgressSummary(this._subjects);
+
   State<StatefulWidget> createState() => ProgressSummaryState(_subjects);
 }
 
 class ProgressSummaryState extends State<ProgressSummary> {
   final List<Subject> _subjects;
+
   ProgressSummaryState(this._subjects);
 
   Widget build(BuildContext context) {
@@ -84,6 +87,7 @@ class ProgressSummaryState extends State<ProgressSummary> {
 // ignore: must_be_immutable
 class SubjectCardProgressBar extends StatelessWidget {
   Subject _subject;
+
   SubjectCardProgressBar(this._subject);
 
   Widget build(BuildContext context) {
@@ -112,12 +116,15 @@ class SubjectCardProgressBar extends StatelessWidget {
 
 class ChartPage extends StatefulWidget {
   final List<Subject> _subjects;
+
   ChartPage(this._subjects);
+
   ChartPageState createState() => ChartPageState(_subjects);
 }
 
 class ChartPageState extends State<ChartPage> with TickerProviderStateMixin {
   ChartPageState(this._subjects);
+
   static const size = const Size(390, 50.0);
   final random = Random();
 

--- a/test/unit_tests/store_test.dart
+++ b/test/unit_tests/store_test.dart
@@ -37,7 +37,7 @@ void main() {
 
   testWidgets('reducer updates subject', (tester) async {
     var createApp = _createApp();
-    createApp.store.dispatch(UpdateSubject(_getDummySubject()));
+    createApp.store.dispatch(UpdateSubject(_getDummySubject(),new SubjectOverview()));
     await tester.pumpWidget(createApp);
     await tester.pump();
     // TODO: 23.05.2019 How to test, if this worked?


### PR DESCRIPTION
i   changed the  _updateSubject() method of the app_state.dart class, so the user can choose to which widget the method will be linked.
The original problem was that andi didnt want to switch to subject overview when the stop button was pressed. This happened because the stopp button called the Update Subject method.